### PR TITLE
Add table to boilerplates index page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11670,6 +11670,11 @@
         "react-is": "^16.12.0 || ^17.0.0"
       }
     },
+    "react-table": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.7.0.tgz",
+      "integrity": "sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA=="
+    },
     "react-test-renderer": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-moment": "^1.0.0",
     "react-quill": "^1.3.5",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "^3.4.4"
+    "react-scripts": "^3.4.4",
+    "react-table": "^7.7.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/Components/Boilerplates.js
+++ b/src/Components/Boilerplates.js
@@ -7,6 +7,7 @@ import Form from "react-bootstrap/Form";
 import Modal from "./Elements/Modal";
 import { useCurrentOrganizationContext } from "../Contexts/currentOrganizationContext";
 import { getAllBoilerplates } from "../Services/Organizations/BoilerplatesService";
+import BoilerplatesTable from "./Boilerplates/BoilerplatesTable";
 
 export default function Boilerplates(props) {
   const [loading, setLoading] = useState(true);
@@ -205,6 +206,8 @@ export default function Boilerplates(props) {
             </Form.Group>
           </Form>
         </div>
+
+        <BoilerplatesTable boilerplates={filteredBoilerplates} />
 
         {highlightedBoilerplates}
       </div>

--- a/src/Components/Boilerplates.js
+++ b/src/Components/Boilerplates.js
@@ -1,4 +1,4 @@
-import React, { Component, useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import BoilerplatesNew from "./BoilerplatesNew";
 import Card from "react-bootstrap/Card";
@@ -17,12 +17,9 @@ export default function Boilerplates(props) {
   const [sortParam, setSortParam] = useState("");
   const {
     currentOrganizationStore,
-    currentOrganizationDispatch,
     organizationClient,
   } = useCurrentOrganizationContext();
-  const currentOrganizationId =
-    currentOrganizationStore.currentOrganization &&
-    currentOrganizationStore.currentOrganization.id;
+  const currentOrganizationId = currentOrganizationStore.currentOrganization?.id;
 
   const [show, setShow] = useState(false);
   const handleClose = (event) => setShow(false);
@@ -41,14 +38,12 @@ export default function Boilerplates(props) {
           setLoading(false);
         });
     }
-  }, [currentOrganizationId]);
+  }, [organizationClient, currentOrganizationId]);
 
   const updateBoilerplates = (newBoilerplate) => {
     const newBoilerplates = [...boilerplates, newBoilerplate];
     setFilteredBoilerplates(newBoilerplates);
   };
-
-  useEffect(() => {}, [filteredBoilerplates]);
 
   const handleSearchParamSelect = (event) => {
     setFilterParam(event.target.value);
@@ -58,17 +53,17 @@ export default function Boilerplates(props) {
     setSortParam(event.target.value);
   };
 
-  const sortBoilerplates = (sortParam) => {
+  const sortBoilerplates = useCallback((sortParam) => {
     const filteredBoilerplatesClone = [...filteredBoilerplates];
     filteredBoilerplatesClone.sort(function (a, b) {
       return a[sortParam].localeCompare(b[sortParam]);
     });
     setFilteredBoilerplates(filteredBoilerplatesClone);
-  };
+  }, [filteredBoilerplates]);
 
   useEffect(() => {
     sortBoilerplates(sortParam);
-  }, [sortParam]);
+  }, [sortBoilerplates, sortParam]);
 
   const handleChange = (event) => {
     const searchValue = event.target.value.toLowerCase();
@@ -94,6 +89,7 @@ export default function Boilerplates(props) {
       filteredByText = boilerplates.filter((boilerplate) => {
         return boilerplate.text.toLowerCase().indexOf(searchValue) !== -1;
       });
+      setFilteredBoilerplates(filteredByText);
     }
   };
 

--- a/src/Components/Boilerplates.js
+++ b/src/Components/Boilerplates.js
@@ -41,7 +41,7 @@ export default function Boilerplates(props) {
     );
 
     return { ...boilerplate, markedOnCategory, markedOnMaxWordCount };
-  })
+  });
 
   useEffect(() => {
     if (currentOrganizationId) {
@@ -70,7 +70,7 @@ export default function Boilerplates(props) {
     boilerplates
       .map(boilerplate => boilerplate.category_name)
       .sort()
-  )
+  );
 
   return (
     <div className="container">

--- a/src/Components/Boilerplates.js
+++ b/src/Components/Boilerplates.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import BoilerplatesNew from "./BoilerplatesNew";
 import Card from "react-bootstrap/Card";
@@ -155,7 +155,7 @@ export default function Boilerplates(props) {
   return (
     <div className="container">
       <h1>Boilerplates</h1>
-      <Button onClick={handleShow}>Add Content</Button>
+      <Button onClick={handleShow}>Add New Boilerplate</Button>
       <div>
         <Modal onClose={handleClose} show={show}>
           <BoilerplatesNew updateBoilerplates={updateBoilerplates} />

--- a/src/Components/Boilerplates.js
+++ b/src/Components/Boilerplates.js
@@ -53,17 +53,17 @@ export default function Boilerplates(props) {
     setSortParam(event.target.value);
   };
 
-  const sortBoilerplates = useCallback((sortParam) => {
-    const filteredBoilerplatesClone = [...filteredBoilerplates];
-    filteredBoilerplatesClone.sort(function (a, b) {
-      return a[sortParam].localeCompare(b[sortParam]);
-    });
-    setFilteredBoilerplates(filteredBoilerplatesClone);
-  }, [filteredBoilerplates]);
+  // const sortBoilerplates = useCallback((sortParam) => {
+  //   const filteredBoilerplatesClone = [...filteredBoilerplates];
+  //   filteredBoilerplatesClone.sort(function (a, b) {
+  //     return a[sortParam].localeCompare(b[sortParam]);
+  //   });
+  //   setFilteredBoilerplates(filteredBoilerplatesClone);
+  // }, [filteredBoilerplates]);
 
-  useEffect(() => {
-    sortBoilerplates(sortParam);
-  }, [sortBoilerplates, sortParam]);
+  // useEffect(() => {
+  //   sortBoilerplates(sortParam);
+  // }, [sortBoilerplates, sortParam]);
 
   const handleChange = (event) => {
     const searchValue = event.target.value.toLowerCase();

--- a/src/Components/Boilerplates/BoilerplatesTable.css
+++ b/src/Components/Boilerplates/BoilerplatesTable.css
@@ -1,0 +1,3 @@
+.BoilerplatesTable {
+  width: 100%;
+}

--- a/src/Components/Boilerplates/BoilerplatesTable.js
+++ b/src/Components/Boilerplates/BoilerplatesTable.js
@@ -40,19 +40,30 @@ export default function BoilerplatesTable(props) {
   const body = rows.map((row) => {
     prepareRow(row);
 
-    const { id } = row.original;
+    const { id, markedOnCategory, markedOnMaxWordCount } = row.original;
     const boilerplateLink = buildOrganizationsLink(`/boilerplates/${id}`);
 
     return (
       <tr {...row.getRowProps()}>
-        {row.cells.map((cell) => (
-          <td {...cell.getCellProps()}>
-            {cell.column.Header === 'Title'
-              ? <Link to={boilerplateLink}>{cell.render("Cell")}</Link>
-              : cell.render("Cell")
+        {row.cells.map((cell) => {
+          const renderedCell = (() => {
+            if (cell.column.Header === 'Title') {
+              return <Link to={boilerplateLink}>{cell.render("Cell")}</Link>
+            } else if (
+              (cell.column.Header === 'Category' && markedOnCategory) ||
+              (cell.column.Header === 'Word Count' && markedOnMaxWordCount)
+            ) {
+              return <mark>{cell.render("Cell")}</mark>
             }
-          </td>
-        ))}
+            return cell.render("Cell")
+          })();
+
+          return (
+            <td {...cell.getCellProps()}>
+              {renderedCell}
+            </td>
+          )}
+        )}
       </tr>
     );
   });

--- a/src/Components/Boilerplates/BoilerplatesTable.js
+++ b/src/Components/Boilerplates/BoilerplatesTable.js
@@ -1,6 +1,8 @@
 import { format as formatDate, parseISO } from "date-fns";
 import React, { useMemo } from "react";
 import { useTable } from "react-table";
+import './BoilerplatesTable.css'
+
 const renderDateColumn = (dateString) => formatDate(parseISO(dateString), 'PP')
 
 export default function BoilerplatesTable(props) {
@@ -46,7 +48,7 @@ export default function BoilerplatesTable(props) {
   });
 
   return (
-    <table {...getTableProps()}>
+    <table {...getTableProps()} className="BoilerplatesTable">
       <thead>{header}</thead>
       <tbody {...getTableBodyProps()}>{body}</tbody>
     </table>

--- a/src/Components/Boilerplates/BoilerplatesTable.js
+++ b/src/Components/Boilerplates/BoilerplatesTable.js
@@ -1,5 +1,7 @@
+import { format as formatDate, parseISO } from "date-fns";
 import React, { useMemo } from "react";
 import { useTable } from "react-table";
+const renderDateColumn = (dateString) => formatDate(parseISO(dateString), 'PP')
 
 export default function BoilerplatesTable(props) {
   const columns = useMemo(
@@ -7,8 +9,8 @@ export default function BoilerplatesTable(props) {
       { Header: "Title", accessor: "title" },
       { Header: "Category", accessor: "category_name" },
       { Header: "Word Count", accessor: "wordcount" },
-      { Header: "Date Created", accessor: "created_at" },
-      { Header: "Last Modified", accessor: "updated_at" },
+      { Header: "Date Created", accessor: (row) => renderDateColumn(row.created_at) },
+      { Header: "Last Modified", accessor: (row) => renderDateColumn(row.updated_at) },
     ],
     []
   );

--- a/src/Components/Boilerplates/BoilerplatesTable.js
+++ b/src/Components/Boilerplates/BoilerplatesTable.js
@@ -5,7 +5,7 @@ import { useTable } from "react-table";
 import useBuildOrganizationsLink from "../../Hooks/useBuildOrganizationsLink";
 import './BoilerplatesTable.css'
 
-const renderDateColumn = (dateString) => formatDate(parseISO(dateString), 'PP')
+const renderDateColumn = (dateString) => formatDate(parseISO(dateString), 'PP');
 
 export default function BoilerplatesTable(props) {
   const columns = useMemo(
@@ -16,7 +16,7 @@ export default function BoilerplatesTable(props) {
       { Header: "Date Created", accessor: (row) => renderDateColumn(row.created_at) },
       { Header: "Last Modified", accessor: (row) => renderDateColumn(row.updated_at) },
     ],
-    []
+    [],
   );
   const boilerplates = useMemo(() => props.boilerplates, [props.boilerplates]);
   const {
@@ -48,22 +48,22 @@ export default function BoilerplatesTable(props) {
         {row.cells.map((cell) => {
           const renderedCell = (() => {
             if (cell.column.Header === 'Title') {
-              return <Link to={boilerplateLink}>{cell.render("Cell")}</Link>
+              return <Link to={boilerplateLink}>{cell.render("Cell")}</Link>;
             } else if (
               (cell.column.Header === 'Category' && markedOnCategory) ||
               (cell.column.Header === 'Word Count' && markedOnMaxWordCount)
             ) {
-              return <mark>{cell.render("Cell")}</mark>
+              return <mark>{cell.render("Cell")}</mark>;
             }
-            return cell.render("Cell")
+            return cell.render("Cell");
           })();
 
           return (
             <td {...cell.getCellProps()}>
               {renderedCell}
             </td>
-          )}
-        )}
+          );
+        })}
       </tr>
     );
   });

--- a/src/Components/Boilerplates/BoilerplatesTable.js
+++ b/src/Components/Boilerplates/BoilerplatesTable.js
@@ -1,6 +1,8 @@
 import { format as formatDate, parseISO } from "date-fns";
 import React, { useMemo } from "react";
+import { Link } from "react-router-dom";
 import { useTable } from "react-table";
+import useBuildOrganizationsLink from "../../Hooks/useBuildOrganizationsLink";
 import './BoilerplatesTable.css'
 
 const renderDateColumn = (dateString) => formatDate(parseISO(dateString), 'PP')
@@ -24,6 +26,7 @@ export default function BoilerplatesTable(props) {
     rows,
     prepareRow
   } = useTable({ columns, data: boilerplates });
+  const buildOrganizationsLink = useBuildOrganizationsLink();
 
   const header = headerGroups.map((headerGroup) => (
     <tr {...headerGroup.getHeaderGroupProps()}>
@@ -36,11 +39,18 @@ export default function BoilerplatesTable(props) {
   ));
   const body = rows.map((row) => {
     prepareRow(row);
+
+    const { id } = row.original;
+    const boilerplateLink = buildOrganizationsLink(`/boilerplates/${id}`);
+
     return (
       <tr {...row.getRowProps()}>
         {row.cells.map((cell) => (
           <td {...cell.getCellProps()}>
-            {cell.render("Cell")}
+            {cell.column.Header === 'Title'
+              ? <Link to={boilerplateLink}>{cell.render("Cell")}</Link>
+              : cell.render("Cell")
+            }
           </td>
         ))}
       </tr>

--- a/src/Components/Boilerplates/BoilerplatesTable.js
+++ b/src/Components/Boilerplates/BoilerplatesTable.js
@@ -1,0 +1,52 @@
+import React, { useMemo } from "react";
+import { useTable } from "react-table";
+
+export default function BoilerplatesTable(props) {
+  const columns = useMemo(
+    () => [
+      { Header: "Title", accessor: "title" },
+      { Header: "Category", accessor: "category_name" },
+      { Header: "Word Count", accessor: "wordcount" },
+      { Header: "Date Created", accessor: "created_at" },
+      { Header: "Last Modified", accessor: "updated_at" },
+    ],
+    []
+  );
+  const boilerplates = useMemo(() => props.boilerplates, [props.boilerplates]);
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow
+  } = useTable({ columns, data: boilerplates });
+
+  const header = headerGroups.map((headerGroup) => (
+    <tr {...headerGroup.getHeaderGroupProps()}>
+      {headerGroup.headers.map((column) => (
+        <th {...column.getHeaderProps()}>
+          {column.render("Header")}
+        </th>
+      ))}
+    </tr>
+  ));
+  const body = rows.map((row) => {
+    prepareRow(row);
+    return (
+      <tr {...row.getRowProps()}>
+        {row.cells.map((cell) => (
+          <td {...cell.getCellProps()}>
+            {cell.render("Cell")}
+          </td>
+        ))}
+      </tr>
+    );
+  });
+
+  return (
+    <table {...getTableProps()}>
+      <thead>{header}</thead>
+      <tbody {...getTableBodyProps()}>{body}</tbody>
+    </table>
+  );
+}

--- a/src/Components/Dashboard.js
+++ b/src/Components/Dashboard.js
@@ -13,9 +13,7 @@ export default function Dashboard() {
   console.log(currentUserStore);
   console.log(currentOrganizationStore);
   const history = useHistory();
-  const currentOrganizationId =
-    currentOrganizationStore.currentOrganizationInfo &&
-    currentOrganizationStore.currentOrganizationInfo.id;
+  const currentOrganizationId = currentOrganizationStore.currentOrganization?.id
 
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/Helpers/unique.js
+++ b/src/Helpers/unique.js
@@ -1,0 +1,6 @@
+/**
+ * Removes duplicate elements from an array.
+ */
+export default function unique(array) {
+  return [...new Set(array)];
+}

--- a/src/Helpers/unique.test.js
+++ b/src/Helpers/unique.test.js
@@ -1,0 +1,13 @@
+import unique from "./unique"
+
+describe('unique', () => {
+  it('removes duplicate elements from an array', () => {
+    expect(unique(['a', 'b', 'a'])).toEqual(['a', 'b']);
+    expect(unique([1, 1, 3, 4, 3])).toEqual([1, 3, 4]);
+  });
+
+  it('returns the same array when no duplicates are present', () => {
+    expect(unique([])).toEqual([]);
+    expect(unique(['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/src/Hooks/useBuildOrganizationsLink.js
+++ b/src/Hooks/useBuildOrganizationsLink.js
@@ -1,0 +1,10 @@
+import { useCurrentOrganizationContext } from "../Contexts/currentOrganizationContext";
+
+export default function useBuildOrganizationsLink() {
+  const { currentOrganizationStore } = useCurrentOrganizationContext();
+  const currentOrganizationId = currentOrganizationStore.currentOrganization?.id;
+
+  return (path) => {
+    return `/organizations/${currentOrganizationId}${path}`;
+  };
+}


### PR DESCRIPTION
## Overview
Closes #135

This sets up a table on the [boilerplates page](http://localhost:3001/organizations/9/boilerplates/) with two inputs for marking boilerplates by category name search or max word count search. The library [react-table](https://react-table.tanstack.com/docs/overview) was made of use to accomplish this.

## Questions
I added the link to the boilerplate onto the title. Not sure if this should actually be on the whole row or somewhere else. Lmk!
The "Search" text box is not implemented in this PR currently. It this meant to search on all the column fields or just the title?

## Screenshots
![Boilerplates Index page](https://user-images.githubusercontent.com/23223956/119274198-58127e80-bbd4-11eb-9862-faaa1a1b7879.png)
